### PR TITLE
Support atomic response if we only have one array element

### DIFF
--- a/src/Response/Cursor.php
+++ b/src/Response/Cursor.php
@@ -65,9 +65,15 @@ class Cursor implements \Iterator
     {
         $this->seek();
 
-        if ($this->valid()) {
-            return $this->response->getData()[$this->index];
+        if (!$this->valid()) {
+            return;
         }
+
+        if ($this->response->isAtomic()) {
+            return $this->response->getData();
+        }
+
+        return $this->response->getData()[$this->index];
     }
 
     /**

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -6,29 +6,25 @@ namespace TBolier\RethinkQL\Response;
 class Response implements ResponseInterface
 {
     /**
-     * @var int
+     * @var array|null
      */
-    private $type;
-
+    private $backtrace;
     /**
      * @var array|null
      */
     private $data;
-
-    /**
-     * @var array|null
-     */
-    private $backtrace;
-
-    /**
-     * @var array|null
-     */
-    private $profile;
-
     /**
      * @var array|null
      */
     private $note;
+    /**
+     * @var array|null
+     */
+    private $profile;
+    /**
+     * @var int
+     */
+    private $type;
 
     /**
      * @param int|null $t
@@ -47,7 +43,7 @@ class Response implements ResponseInterface
     }
 
     /**
-     * @return int
+     * @inheritdoc
      */
     public function getType(): ?int
     {
@@ -55,15 +51,27 @@ class Response implements ResponseInterface
     }
 
     /**
-     * @return array
+     * @inheritdoc
      */
-    public function getData(): ?array
+    public function getData()
     {
-        return $this->data;
+        if (!\is_array($this->data)) {
+            return null;
+        }
+
+        return \count($this->data) === 1 && array_key_exists(0, $this->data) ? $this->data[0] : $this->data;
     }
 
     /**
-     * @return array
+     * @return bool
+     */
+    public function isAtomic(): bool
+    {
+        return \count($this->data) === 1;
+    }
+
+    /**
+     * @inheritdoc
      */
     public function getBacktrace(): ?array
     {
@@ -71,7 +79,7 @@ class Response implements ResponseInterface
     }
 
     /**
-     * @return array
+     * @inheritdoc
      */
     public function getProfile(): ?array
     {
@@ -79,7 +87,7 @@ class Response implements ResponseInterface
     }
 
     /**
-     * @return array
+     * @inheritdoc
      */
     public function getNote(): ?array
     {

--- a/src/Response/ResponseInterface.php
+++ b/src/Response/ResponseInterface.php
@@ -11,9 +11,14 @@ interface ResponseInterface
     public function getType(): ?int;
 
     /**
-     * @return array
+     * @return string|array
      */
-    public function getData(): ?array;
+    public function getData();
+
+    /**
+     * @return bool
+     */
+    public function isAtomic(): bool;
 
     /**
      * @return array

--- a/test/integration/BaseTestCase.php
+++ b/test/integration/BaseTestCase.php
@@ -49,7 +49,7 @@ class BaseTestCase extends TestCase
 
         $this->r = new Rethink($connection);
 
-        if (!\in_array('test', $this->r->dbList()->run()->getData()[0], true)) {
+        if (!\in_array('test', $this->r->dbList()->run()->getData(), true)) {
             $this->r->dbCreate('test')->run();
         }
 
@@ -59,7 +59,7 @@ class BaseTestCase extends TestCase
     protected function tearDown()
     {
         if ($this->r !== null && \in_array('test',
-                $this->r->dbList()->run()->getData()[0], true)) {
+                $this->r->dbList()->run()->getData(), true)) {
             $this->r->dbDrop('test')->run();
         }
     }

--- a/test/integration/Connection/ConnectionTest.php
+++ b/test/integration/Connection/ConnectionTest.php
@@ -35,7 +35,7 @@ class ConnectionTest extends BaseTestCase
         $result = $connection->expr('foo');
 
         $this->assertInstanceOf(ResponseInterface::class, $result);
-        $this->assertEquals('foo', $result->getData()[0]);
+        $this->assertEquals('foo', $result->getData());
     }
 
     /**
@@ -47,6 +47,6 @@ class ConnectionTest extends BaseTestCase
         $res = $this->createConnection('phpunit_default')->connect()->server();
 
         $this->assertEquals(QueryType::SERVER_INFO, $res->getType());
-        $this->assertInternalType('string', $res->getData()[0]['name']);
+        $this->assertInternalType('string', $res->getData()['name']);
     }
 }

--- a/test/integration/Query/CursorTest.php
+++ b/test/integration/Query/CursorTest.php
@@ -12,14 +12,14 @@ class CursorTest extends BaseTestCase
     {
         parent::setUp();
 
-        if (!\in_array('cursortest', $this->r()->db()->tableList()->run()->getData()[0], true)) {
+        if (!\in_array('cursortest', $this->r()->db()->tableList()->run()->getData(), true)) {
             $this->r()->db()->tableCreate('cursortest')->run();
         }
     }
 
     public function tearDown()
     {
-        if (\in_array('cursortest', $this->r()->db()->tableList()->run()->getData()[0], true)) {
+        if (\in_array('cursortest', $this->r()->db()->tableList()->run()->getData(), true)) {
             $this->r()->db()->tableDrop('cursortest')->run();
         }
 
@@ -38,7 +38,7 @@ class CursorTest extends BaseTestCase
             ->count()
             ->run();
 
-        $this->assertEquals(1000, $response->getData()[0]);
+        $this->assertEquals(1000, $response->getData());
     }
 
     /**
@@ -63,7 +63,7 @@ class CursorTest extends BaseTestCase
             ->insert([$documents])
             ->run();
 
-        $this->assertEquals(1000, $res->getData()[0]['inserted']);
+        $this->assertEquals(1000, $res->getData()['inserted']);
 
         return $res;
     }

--- a/test/integration/Query/DatabaseTest.php
+++ b/test/integration/Query/DatabaseTest.php
@@ -18,7 +18,7 @@ class DatabaseTest extends BaseTestCase
             ->tableList()
             ->run();
 
-        $this->assertInternalType('array', $res->getData()[0]);
+        $this->assertInternalType('array', $res->getData());
     }
 
     /**
@@ -31,7 +31,7 @@ class DatabaseTest extends BaseTestCase
             ->tableCreate('createtable')
             ->run();
 
-        $this->assertObStatus(['tables_created' => 1], $res->getData()[0]);
+        $this->assertObStatus(['tables_created' => 1], $res->getData());
     }
 
     /**
@@ -49,7 +49,7 @@ class DatabaseTest extends BaseTestCase
             ->tableDrop('createtable')
             ->run();
 
-        $this->assertObStatus(['tables_dropped' => 1], $res->getData()[0]);
+        $this->assertObStatus(['tables_dropped' => 1], $res->getData());
     }
 
     /**

--- a/test/integration/Query/TableTest.php
+++ b/test/integration/Query/TableTest.php
@@ -14,14 +14,14 @@ class TableTest extends BaseTestCase
     {
         parent::setUp();
 
-        if (!\in_array('tabletest', $this->r()->db()->tableList()->run()->getData()[0], true)) {
+        if (!\in_array('tabletest', $this->r()->db()->tableList()->run()->getData(), true)) {
             $this->r()->db()->tableCreate('tabletest')->run();
         }
     }
 
     public function tearDown()
     {
-        if (\in_array('tabletest', $this->r()->db()->tableList()->run()->getData()[0], true)) {
+        if (\in_array('tabletest', $this->r()->db()->tableList()->run()->getData(), true)) {
             $this->r()->db()->tableDrop('tabletest')->run();
         }
 
@@ -44,14 +44,14 @@ class TableTest extends BaseTestCase
             ->count()
             ->run();
 
-        $this->assertInternalType('int', $count->getData()[0]);
+        $this->assertInternalType('int', $count->getData());
 
         $res = $this->r()
             ->table('tabletest')
             ->delete()
             ->run();
 
-        $this->assertObStatus(['deleted' => $count->getData()[0]], $res->getData()[0]);
+        $this->assertObStatus(['deleted' => $count->getData()], $res->getData());
     }
 
     /**
@@ -61,7 +61,7 @@ class TableTest extends BaseTestCase
     {
         $res = $this->insertDocument(1);
 
-        $this->assertObStatus(['inserted' => 1], $res->getData()[0]);
+        $this->assertObStatus(['inserted' => 1], $res->getData());
     }
 
     /**
@@ -76,7 +76,7 @@ class TableTest extends BaseTestCase
             ->count()
             ->run();
 
-        $this->assertInternalType('int', $res->getData()[0]);
+        $this->assertInternalType('int', $res->getData());
     }
 
     /**
@@ -122,7 +122,7 @@ class TableTest extends BaseTestCase
             ->count()
             ->run();
 
-        $this->assertEquals(5, $res->getData()[0]);
+        $this->assertEquals(5, $res->getData());
     }
 
     /**
@@ -166,7 +166,7 @@ class TableTest extends BaseTestCase
             ])
             ->run();
 
-        $this->assertObStatus(['replaced' => $count->getData()[0]], $res->getData()[0]);
+        $this->assertObStatus(['replaced' => $count->getData()], $res->getData());
     }
 
     /**
@@ -194,7 +194,7 @@ class TableTest extends BaseTestCase
             ->count()
             ->run();
 
-        $this->assertInternalType('int', $count->getData()[0]);
+        $this->assertInternalType('int', $count->getData());
 
         /** @var ResponseInterface $res */
         $res = $this->r()
@@ -207,7 +207,7 @@ class TableTest extends BaseTestCase
             ->delete()
             ->run();
 
-        $this->assertObStatus(['deleted' => $count->getData()[0]], $res->getData()[0]);
+        $this->assertObStatus(['deleted' => $count->getData()], $res->getData());
     }
 
     /**
@@ -231,7 +231,7 @@ class TableTest extends BaseTestCase
             ->get('foo')
             ->run();
 
-        $this->assertEquals([0 => ['id' => 'foo']], $res->getData());
+        $this->assertEquals(['id' => 'foo'], $res->getData());
     }
 
     /**
@@ -246,7 +246,7 @@ class TableTest extends BaseTestCase
             ->get('bar')
             ->run();
 
-        $this->assertEquals([0 => null], $res->getData());
+        $this->assertEquals(null, $res->getData());
     }
 
     /**


### PR DESCRIPTION
## Purpose
When `ResponseInterface` is returned, and the `getData` method is called, if there is an atomic data array with only one element, it would result for example in: `getData()[0]['inserted'] === 1`. When there is one array element we can return it immediately. In the earlier example this would result in cleaner code `getData()['inserted'] === 1`.

## Approach
Add an `isAtomic` check to the `ResponseInterface` so callers can identify whether the response data is atomic.

## Solution

Afterwards we could remove all the unnecessary index 0 key references.
