### PR TITLE
Fixed cursor iteration seek and rewind bugs

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TBolier\RethinkQL\Connection;
 
@@ -132,10 +132,7 @@ class Connection implements ConnectionInterface, ConnectionCursorInterface
      */
     public function continueQuery(int $token): ResponseInterface
     {
-        $message = (new Message())->setQuery(
-            [QueryType::CONTINUE]
-        );
-
+        $message = new Message(QueryType::CONTINUE);
         $this->writeQuery($token, $message);
 
         // Await the response
@@ -224,10 +221,10 @@ class Connection implements ConnectionInterface, ConnectionCursorInterface
         try {
             $token = $this->generateToken();
 
-            $query = new Message(QueryType::SERVER_INFO);
-            $this->writeQuery($token, $query);
+            $message = new Message(QueryType::SERVER_INFO);
+            $this->writeQuery($token, $message);
 
-            $response = $this->receiveResponse($token, $query);
+            $response = $this->receiveResponse($token, $message);
 
             if ($response->getType() !== 5) {
                 throw new ConnectionException('Unexpected response type for server query.');
@@ -245,9 +242,7 @@ class Connection implements ConnectionInterface, ConnectionCursorInterface
      */
     public function stopQuery(int $token): ResponseInterface
     {
-        $message = (new Message())->setQuery(
-            [QueryType::STOP]
-        );
+        $message = new Message(QueryType::STOP);
 
         $this->writeQuery($token, $message);
 
@@ -283,9 +278,9 @@ class Connection implements ConnectionInterface, ConnectionCursorInterface
         }
 
         $requestSize = pack('V', \strlen($request));
-        $binaryToken = pack('V', $token).pack('V', 0);
+        $binaryToken = pack('V', $token) . pack('V', 0);
 
-        return $this->stream->write($binaryToken.$requestSize.$request);
+        return $this->stream->write($binaryToken . $requestSize . $request);
     }
 
     /**
@@ -298,10 +293,10 @@ class Connection implements ConnectionInterface, ConnectionCursorInterface
         try {
             $token = $this->generateToken();
 
-            $query = new Message(QueryType::NOREPLY_WAIT);
-            $this->writeQuery($token, $query);
+            $message = new Message(QueryType::NOREPLY_WAIT);
+            $this->writeQuery($token, $message);
 
-            $response = $this->receiveResponse($token, $query);
+            $response = $this->receiveResponse($token, $message);
 
             if ($response->getType() !== 4) {
                 throw new ConnectionException('Unexpected response type for noreplyWait query.');
@@ -396,22 +391,22 @@ class Connection implements ConnectionInterface, ConnectionCursorInterface
         }
 
         if ($response->getType() === ResponseType::CLIENT_ERROR) {
-            throw new ConnectionException('Client error: '.$response->getData()[0].' jsonQuery: '.json_encode($message));
+            throw new ConnectionException('Client error: ' . $response->getData()[0] . ' jsonQuery: ' . json_encode($message));
         }
 
         if ($responseToken !== $token) {
             throw new ConnectionException(
                 'Received wrong token. Response does not match the request. '
-                . 'Expected '.$token.', received '.$responseToken
+                . 'Expected ' . $token . ', received ' . $responseToken
             );
         }
 
         if ($response->getType() === ResponseType::COMPILE_ERROR) {
-            throw new ConnectionException('Compile error: '.$response->getData()[0].', jsonQuery: '.json_encode($message));
+            throw new ConnectionException('Compile error: ' . $response->getData()[0] . ', jsonQuery: ' . json_encode($message));
         }
 
         if ($response->getType() === ResponseType::RUNTIME_ERROR) {
-            throw new ConnectionException('Runtime error: '.$response->getData()[0].', jsonQuery: '.json_encode($message));
+            throw new ConnectionException('Runtime error: ' . $response->getData()[0] . ', jsonQuery: ' . json_encode($message));
         }
     }
 }

--- a/src/Response/Cursor.php
+++ b/src/Response/Cursor.php
@@ -109,8 +109,11 @@ class Cursor implements \Iterator, \Countable
      */
     public function rewind(): void
     {
-        $this->close();
+        if ($this->index === 0) {
+            return;
+        }
 
+        $this->close();
         $this->addResponse($this->connection->rewindFromCursor($this->message));
     }
 
@@ -139,11 +142,7 @@ class Cursor implements \Iterator, \Countable
      */
     private function seek(): void
     {
-        while ($this->index === $this->size) {
-            if ($this->isComplete) {
-                return;
-            }
-
+        if ($this->index >= $this->size && !$this->isComplete) {
             $this->request();
         }
     }

--- a/test/integration/AbstractTestCase.php
+++ b/test/integration/AbstractTestCase.php
@@ -46,16 +46,19 @@ abstract class AbstractTestCase extends TestCase
             return $this->r;
         }
 
+        $name = 'phpunit_default';
+        $options = new Options(PHPUNIT_CONNECTIONS[$name]);
+
         /** @var ConnectionInterface $connection */
-        $connection = $this->createConnection('phpunit_default')->connect();
-        $connection->connect()->use('test');
+        $connection = $this->createConnection($name)->connect();
+        $connection->connect()->use($options->getDbName());
 
         $this->r = new Rethink($connection);
 
         /** @var ResponseInterface $res */
         $res = $this->r->dbList()->run();
-        if (\is_array($res->getData()) && !\in_array('test', $res->getData(), true)) {
-            $this->r->dbCreate('test')->run();
+        if (\is_array($res->getData()) && !\in_array($options->getDbName(), $res->getData(), true)) {
+            $this->r->dbCreate($options->getDbName())->run();
         }
 
         return $this->r;
@@ -67,10 +70,13 @@ abstract class AbstractTestCase extends TestCase
             return;
         }
 
+        $name = 'phpunit_default';
+        $options = new Options(PHPUNIT_CONNECTIONS[$name]);
+
         /** @var ResponseInterface $res */
         $res = $this->r->dbList()->run();
-        if (\is_array($res->getData()) && \in_array('test', $res->getData(), true)) {
-            $this->r->dbDrop('test')->run();
+        if (\is_array($res->getData()) && \in_array($options->getDbName(), $res->getData(), true)) {
+            $this->r->dbDrop($options->getDbName())->run();
         }
     }
 

--- a/test/integration/Query/AbstractTableTest.php
+++ b/test/integration/Query/AbstractTableTest.php
@@ -24,8 +24,6 @@ abstract class AbstractTableTest extends AbstractTestCase
         if (\is_array($res->getData()) && \in_array('tabletest', $res->getData(), true)) {
             $this->r()->db()->tableDrop('tabletest')->run();
         }
-
-        parent::tearDown();
     }
 
     /**

--- a/test/integration/Query/CursorTest.php
+++ b/test/integration/Query/CursorTest.php
@@ -3,10 +3,31 @@ declare(strict_types = 1);
 
 namespace TBolier\RethinkQL\IntegrationTest\Query;
 
+use TBolier\RethinkQL\Response\Cursor;
 use TBolier\RethinkQL\Response\ResponseInterface;
 
 class CursorTest extends AbstractTableTest
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $res = $this->r()->db()->tableList()->run();
+        if (\is_array($res->getData()) && !\in_array('tabletest_big', $res->getData(), true)) {
+            $this->r()->db()->tableCreate('tabletest_big')->run();
+        }
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $res = $this->r()->db()->tableList()->run();
+        if (\is_array($res->getData()) && \in_array('tabletest_big', $res->getData(), true)) {
+            $this->r()->db()->tableDrop('tabletest_big')->run();
+        }
+    }
+
     /**
      * @throws \Exception
      */
@@ -20,6 +41,52 @@ class CursorTest extends AbstractTableTest
             ->run();
 
         $this->assertEquals(1000, $response->getData());
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testCursorBigDocuments()
+    {
+        $data = [
+            'Professor X' => 'Charles Francis Xavier',
+            'Cyclops' => 'Scott Summers',
+            'Iceman' => 'Robert Louis "Bobby" Drake',
+            'Angel' => 'Warren Kenneth Worthington III',
+            'Beast' => 'Henry Philip "Hank" McCoy',
+            'Marvel Girl/Phoenix' => 'Jean Elaine Grey/Jean Elaine Grey-Summers',
+            'Magnetrix/Polaris' => 'Lorna Sally Dane',
+            'Nightcrawler' => 'Kurt Wagner',
+            'Wolverine' => 'James "Logan" Howlett',
+            'Storm' => 'Ororo Monroe',
+            'Colossus' => 'Piotr Nikolaievitch "Peter" Rasputin',
+            'Sprite/Ariel/Shadowcat' => 'Katherine Anne "Kitty" Pryde',
+            'Rogue' => 'Anna Marie',
+            'Phoenix/Marvel Girl/Prestige' => 'Rachel Anne Grey-Summers',
+            'Psylocke' => 'Elizabeth "Betsy" Braddock',
+            'Gambit' => 'Rémy Etienne LeBeau',
+            'Jubilee' => 'Jubilation Lee',
+            'Bishop' => 'Lucas Bishop',
+        ];
+
+        $this->insertBigDocuments($data);
+
+        $cursor = $this->r()->table('tabletest_big')->run();
+
+        $i = 0;
+        foreach ($cursor as $document) {
+            // Assert the document every 1000s documents.
+            if ($i % 1000 === 0) {
+                $this->assertArraySubset($data, $document);
+            }
+            $i++;
+        }
+
+        $this->assertEquals($i, $this->r()->table('tabletest_big')->count()->run()->getData());
+
+        $this->assertInstanceOf(Cursor::class, $cursor);
+
+        $this->r()->table('tabletest_big')->delete()->run();
     }
 
     /**
@@ -45,6 +112,32 @@ class CursorTest extends AbstractTableTest
             ->run();
 
         $this->assertEquals(1000, $res->getData()['inserted']);
+
+        return $res;
+    }
+
+    /**
+     * @param array $data
+     * @return ResponseInterface
+     * @throws \Exception
+     */
+    private function insertBigDocuments(array $data): ResponseInterface
+    {
+        for ($i = 1; $i <= 100; $i++) {
+            $documents = [];
+
+            for ($x = 1; $x <= 100; $x++) {
+                $documents[] = $data;
+            }
+
+            /** @var ResponseInterface $res */
+            $res = $this->r()
+                ->table('tabletest_big')
+                ->insert($documents)
+                ->run();
+
+            $this->assertEquals(100, $res->getData()['inserted']);
+        }
 
         return $res;
     }

--- a/test/unit/Connection/ConnectionQueryTest.php
+++ b/test/unit/Connection/ConnectionQueryTest.php
@@ -5,6 +5,7 @@ namespace TBolier\RethinkQL\UnitTest\Connection;
 
 use TBolier\RethinkQL\Message\MessageInterface;
 use TBolier\RethinkQL\Response\ResponseInterface;
+use TBolier\RethinkQL\Types\Query\QueryType;
 use TBolier\RethinkQL\Types\Response\ResponseType;
 
 class ConnectionQueryTest extends ConnectionTestCase


### PR DESCRIPTION
## Purpose
Looping over a Cursor which contained large documents did not work, resulting in an error

## Approach
I had to figure out what was happening internally, and came to the conclusion a wrong QueryType was set for stop queries and continue queries.

## Solution
I am passing the message to continueQuery and stopQuery, and modifying the query type as needed (QueryType::CONTINUE, QueryType::STOP). After the command has executed, I reset the query type to QueryType::START in order to be able to be used further along the line.

I also added a unit test, which populates the database with large documents in order to test the functionality.
