### PR TITLE
 Implement group and ungroup with get field document manipulations

### DIFF
--- a/src/Query/AbstractQuery.php
+++ b/src/Query/AbstractQuery.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace TBolier\RethinkQL\Query;
 
+use TBolier\RethinkQL\Message\Message;
 use TBolier\RethinkQL\Message\MessageInterface;
 use TBolier\RethinkQL\RethinkInterface;
 
@@ -20,12 +21,10 @@ abstract class AbstractQuery implements QueryInterface
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message = null)
+    public function __construct(RethinkInterface $rethink)
     {
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**
@@ -33,9 +32,10 @@ abstract class AbstractQuery implements QueryInterface
      */
     public function run()
     {
-        $this->message->setQuery($this->toArray());
+        $message = new Message();
+        $message->setQuery($this->toArray());
 
-        return $this->rethink->connection()->run($this->message);
+        return $this->rethink->connection()->run($message);
     }
 
     /**

--- a/src/Query/Aggregation/AbstractAggregation.php
+++ b/src/Query/Aggregation/AbstractAggregation.php
@@ -5,6 +5,7 @@ namespace TBolier\RethinkQL\Query\Aggregation;
 
 use TBolier\RethinkQL\Query\AbstractQuery;
 use TBolier\RethinkQL\Query\QueryInterface;
+use TBolier\RethinkQL\Query\Transformation\TransformationCompoundInterface;
 
 abstract class AbstractAggregation extends AbstractQuery implements AggregationInterface
 {
@@ -14,6 +15,22 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
     public function count(): QueryInterface
     {
         return new Count($this->rethink, $this->message, $this);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function group(string $key): TransformationCompoundInterface
+    {
+        return new Group($this->rethink, $this->message, $this, $key);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function ungroup(): TransformationCompoundInterface
+    {
+        return new Ungroup($this->rethink, $this->message, $this);
     }
 
     /**
@@ -43,7 +60,7 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
     /**
      * @inheritdoc
      */
-    public function max(string $key): AggregationInterface
+    public function max(string $key): TransformationCompoundInterface
     {
         return new Max($this->rethink, $this->message, $this, $key);
     }

--- a/src/Query/Aggregation/AbstractAggregation.php
+++ b/src/Query/Aggregation/AbstractAggregation.php
@@ -14,7 +14,7 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
      */
     public function count(): QueryInterface
     {
-        return new Count($this->rethink, $this->message, $this);
+        return new Count($this->rethink, $this);
     }
 
     /**
@@ -22,7 +22,7 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
      */
     public function group(string $key): TransformationCompoundInterface
     {
-        return new Group($this->rethink, $this->message, $this, $key);
+        return new Group($this->rethink, $this, $key);
     }
 
     /**
@@ -30,7 +30,7 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
      */
     public function ungroup(): TransformationCompoundInterface
     {
-        return new Ungroup($this->rethink, $this->message, $this);
+        return new Ungroup($this->rethink, $this);
     }
 
     /**
@@ -38,7 +38,7 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
      */
     public function sum(string $key): QueryInterface
     {
-        return new Sum($this->rethink, $this->message, $this, $key);
+        return new Sum($this->rethink, $this, $key);
     }
 
     /**
@@ -46,7 +46,7 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
      */
     public function avg(string $key): QueryInterface
     {
-        return new Avg($this->rethink, $this->message, $this, $key);
+        return new Avg($this->rethink, $this, $key);
     }
 
     /**
@@ -54,7 +54,7 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
      */
     public function min(string $key): AggregationInterface
     {
-        return new Min($this->rethink, $this->message, $this, $key);
+        return new Min($this->rethink, $this, $key);
     }
 
     /**
@@ -62,6 +62,6 @@ abstract class AbstractAggregation extends AbstractQuery implements AggregationI
      */
     public function max(string $key): TransformationCompoundInterface
     {
-        return new Max($this->rethink, $this->message, $this, $key);
+        return new Max($this->rethink, $this, $key);
     }
 }

--- a/src/Query/Aggregation/AggregationInterface.php
+++ b/src/Query/Aggregation/AggregationInterface.php
@@ -1,9 +1,10 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TBolier\RethinkQL\Query\Aggregation;
 
 use TBolier\RethinkQL\Query\QueryInterface;
+use TBolier\RethinkQL\Query\Transformation\TransformationCompoundInterface;
 use TBolier\RethinkQL\Response\ResponseInterface;
 
 interface AggregationInterface
@@ -12,6 +13,17 @@ interface AggregationInterface
      * @return QueryInterface
      */
     public function count(): QueryInterface;
+
+    /**
+     * @param string $key
+     * @return TransformationCompoundInterface
+     */
+    public function group(string $key): TransformationCompoundInterface;
+
+    /**
+     * @return TransformationCompoundInterface
+     */
+    public function ungroup(): TransformationCompoundInterface;
 
     /**
      * @param string $key
@@ -33,9 +45,9 @@ interface AggregationInterface
 
     /**
      * @param string $key
-     * @return AggregationInterface
+     * @return TransformationCompoundInterface
      */
-    public function max(string $key): AggregationInterface;
+    public function max(string $key): TransformationCompoundInterface;
 
     /**
      * @return Iterable|ResponseInterface

--- a/src/Query/Aggregation/Avg.php
+++ b/src/Query/Aggregation/Avg.php
@@ -22,22 +22,19 @@ class Avg extends AbstractAggregation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $key
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         string $key
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->key = $key;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Aggregation/Count.php
+++ b/src/Query/Aggregation/Count.php
@@ -18,16 +18,14 @@ class Count extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message, QueryInterface $query)
+    public function __construct(RethinkInterface $rethink, QueryInterface $query)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Aggregation/Group.php
+++ b/src/Query/Aggregation/Group.php
@@ -23,22 +23,19 @@ class Group extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $key
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         string $key
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->key = $key;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Aggregation/Group.php
+++ b/src/Query/Aggregation/Group.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TBolier\RethinkQL\Query\Aggregation;
 
@@ -9,7 +9,7 @@ use TBolier\RethinkQL\Query\Transformation\AbstractTransformationCompound;
 use TBolier\RethinkQL\RethinkInterface;
 use TBolier\RethinkQL\Types\Term\TermType;
 
-class Max extends AbstractTransformationCompound
+class Group extends AbstractTransformationCompound
 {
     /**
      * @var string
@@ -47,10 +47,10 @@ class Max extends AbstractTransformationCompound
     public function toArray(): array
     {
         return [
-            TermType::MAX,
+            TermType::GROUP,
             [
                 $this->query->toArray(),
-                $this->key
+                $this->key,
             ],
         ];
     }

--- a/src/Query/Aggregation/Max.php
+++ b/src/Query/Aggregation/Max.php
@@ -23,22 +23,19 @@ class Max extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $key
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         string $key
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->key = $key;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Aggregation/Min.php
+++ b/src/Query/Aggregation/Min.php
@@ -22,22 +22,19 @@ class Min extends AbstractAggregation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $key
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         string $key
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->key = $key;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Aggregation/Sum.php
+++ b/src/Query/Aggregation/Sum.php
@@ -22,22 +22,19 @@ class Sum extends AbstractAggregation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $key
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         string $key
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->key = $key;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Aggregation/Ungroup.php
+++ b/src/Query/Aggregation/Ungroup.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TBolier\RethinkQL\Query\Aggregation;
 
@@ -9,34 +9,26 @@ use TBolier\RethinkQL\Query\Transformation\AbstractTransformationCompound;
 use TBolier\RethinkQL\RethinkInterface;
 use TBolier\RethinkQL\Types\Term\TermType;
 
-class Max extends AbstractTransformationCompound
+    class Ungroup extends AbstractTransformationCompound
 {
-    /**
-     * @var string
-     */
-    private $key;
-
     /**
      * @var QueryInterface
      */
-    private $query;
+      private $query;
 
     /**
      * @param RethinkInterface $rethink
      * @param MessageInterface $message
      * @param QueryInterface $query
-     * @param string $key
      */
     public function __construct(
         RethinkInterface $rethink,
         MessageInterface $message,
-        QueryInterface $query,
-        string $key
+        QueryInterface $query
     ) {
         parent::__construct($rethink, $message);
 
         $this->query = $query;
-        $this->key = $key;
         $this->rethink = $rethink;
         $this->message = $message;
     }
@@ -47,10 +39,9 @@ class Max extends AbstractTransformationCompound
     public function toArray(): array
     {
         return [
-            TermType::MAX,
+            TermType::UNGROUP,
             [
                 $this->query->toArray(),
-                $this->key
             ],
         ];
     }

--- a/src/Query/Aggregation/Ungroup.php
+++ b/src/Query/Aggregation/Ungroup.php
@@ -9,28 +9,25 @@ use TBolier\RethinkQL\Query\Transformation\AbstractTransformationCompound;
 use TBolier\RethinkQL\RethinkInterface;
 use TBolier\RethinkQL\Types\Term\TermType;
 
-    class Ungroup extends AbstractTransformationCompound
+class Ungroup extends AbstractTransformationCompound
 {
     /**
      * @var QueryInterface
      */
-      private $query;
+    private $query;
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -52,7 +52,7 @@ class Builder implements BuilderInterface
             unset($this->table);
         }
 
-        $this->table = new Table($name, $this->rethink, new Message());
+        $this->table = new Table($name, $this->rethink);
 
         return $this->table;
     }
@@ -66,7 +66,7 @@ class Builder implements BuilderInterface
             unset($this->database);
         }
 
-        $this->database = new Database($this->rethink, new Message());
+        $this->database = new Database($this->rethink);
 
         return $this->database;
     }
@@ -81,7 +81,7 @@ class Builder implements BuilderInterface
             unset($this->ordering);
         }
 
-        $this->ordering = new Ordening($key, $this->rethink, new Message());
+        $this->ordering = new Ordening($key, $this->rethink);
 
         return $this->ordering;
     }
@@ -92,7 +92,7 @@ class Builder implements BuilderInterface
      */
     public function row(string $value): RowInterface
     {
-        $this->row = new Row($this->rethink, new Message(), $value);
+        $this->row = new Row($this->rethink, $value);
 
         return $this->row;
     }

--- a/src/Query/Database.php
+++ b/src/Query/Database.php
@@ -21,11 +21,11 @@ class Database extends AbstractQuery implements DatabaseInterface
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
+
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message)
+    public function __construct(RethinkInterface $rethink)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->dbList();
     }
@@ -35,7 +35,7 @@ class Database extends AbstractQuery implements DatabaseInterface
      */
     public function dbCreate(string $name): DatabaseInterface
     {
-        $this->query = new DbCreate($this->rethink, $this->message, $name);
+        $this->query = new DbCreate($this->rethink, $name);
 
         return $this;
     }
@@ -45,7 +45,7 @@ class Database extends AbstractQuery implements DatabaseInterface
      */
     public function dbDrop(string $name): DatabaseInterface
     {
-        $this->query = new DbDrop($this->rethink, $this->message, $name);
+        $this->query = new DbDrop($this->rethink, $name);
 
         return $this;
     }
@@ -55,7 +55,7 @@ class Database extends AbstractQuery implements DatabaseInterface
      */
     public function dbList(): DatabaseInterface
     {
-        $this->query = new DbList($this->rethink, $this->message);
+        $this->query = new DbList($this->rethink);
 
         return $this;
     }
@@ -65,7 +65,7 @@ class Database extends AbstractQuery implements DatabaseInterface
      */
     public function tableList(): DatabaseInterface
     {
-        $this->query = new TableList($this->rethink, $this->message);
+        $this->query = new TableList($this->rethink);
 
         return $this;
     }
@@ -75,7 +75,7 @@ class Database extends AbstractQuery implements DatabaseInterface
      */
     public function tableCreate(string $name): DatabaseInterface
     {
-        $this->query = new TableCreate($this->rethink, $this->message, $name);
+        $this->query = new TableCreate($this->rethink, $name);
 
         return $this;
     }
@@ -85,7 +85,7 @@ class Database extends AbstractQuery implements DatabaseInterface
      */
     public function tableDrop(string $name): DatabaseInterface
     {
-        $this->query = new TableDrop($this->rethink, $this->message, $name);
+        $this->query = new TableDrop($this->rethink, $name);
 
         return $this;
     }

--- a/src/Query/Logic/AndLogic.php
+++ b/src/Query/Logic/AndLogic.php
@@ -22,20 +22,18 @@ class AndLogic extends AbstractOperation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $functionOne
      * @param QueryInterface $functionTwo
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $functionOne,
         QueryInterface $functionTwo
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
+
         $this->functionOne = $functionOne;
         $this->functionTwo = $functionTwo;
     }

--- a/src/Query/Logic/EqualLogic.php
+++ b/src/Query/Logic/EqualLogic.php
@@ -22,21 +22,19 @@ class EqualLogic extends AbstractOperation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param mixed $value
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         $value
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->value = $value;
         $this->rethink = $rethink;
-        $this->message = $message;
+        
         $this->query = $query;
     }
 

--- a/src/Query/Logic/FuncLogic.php
+++ b/src/Query/Logic/FuncLogic.php
@@ -17,18 +17,16 @@ class FuncLogic extends AbstractOperation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
+        
         $this->query = $query;
     }
 

--- a/src/Query/Logic/GetFieldLogic.php
+++ b/src/Query/Logic/GetFieldLogic.php
@@ -23,21 +23,19 @@ class GetFieldLogic extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $field
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         string $field,
         ?QueryInterface $query = null
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->field = $field;
         $this->rethink = $rethink;
-        $this->message = $message;
+
         $this->query = $query;
     }
 

--- a/src/Query/Logic/GetFieldLogic.php
+++ b/src/Query/Logic/GetFieldLogic.php
@@ -4,10 +4,12 @@ namespace TBolier\RethinkQL\Query\Logic;
 
 use TBolier\RethinkQL\Message\MessageInterface;
 use TBolier\RethinkQL\Query\AbstractQuery;
+use TBolier\RethinkQL\Query\QueryInterface;
+use TBolier\RethinkQL\Query\Transformation\AbstractTransformationCompound;
 use TBolier\RethinkQL\RethinkInterface;
 use TBolier\RethinkQL\Types\Term\TermType;
 
-class GetFieldLogic extends AbstractQuery
+class GetFieldLogic extends AbstractTransformationCompound
 {
     /**
      * @var string
@@ -15,20 +17,28 @@ class GetFieldLogic extends AbstractQuery
     private $field;
 
     /**
+     * @var QueryInterface|null
+     */
+    private $query;
+
+    /**
      * @param RethinkInterface $rethink
      * @param MessageInterface $message
+     * @param QueryInterface $query
      * @param string $field
      */
     public function __construct(
         RethinkInterface $rethink,
         MessageInterface $message,
-        string $field
+        string $field,
+        ?QueryInterface $query = null
     ) {
         parent::__construct($rethink, $message);
 
         $this->field = $field;
         $this->rethink = $rethink;
         $this->message = $message;
+        $this->query = $query;
     }
 
     /**
@@ -36,12 +46,22 @@ class GetFieldLogic extends AbstractQuery
      */
     public function toArray(): array
     {
+        if ($this->query !== null) {
+            return [
+                TermType::GET_FIELD,
+                [
+                    $this->query->toArray(),
+                    $this->field
+                ],
+            ];
+        }
+
         return [
             TermType::GET_FIELD,
             [
                 [
-                    13,
-                    [],
+                    TermType::IMPLICIT_VAR,
+                    []
                 ],
                 $this->field
             ],

--- a/src/Query/Logic/GreaterThanLogic.php
+++ b/src/Query/Logic/GreaterThanLogic.php
@@ -22,21 +22,19 @@ class GreaterThanLogic extends AbstractOperation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param $value
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         $value
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->value = $value;
         $this->rethink = $rethink;
-        $this->message = $message;
+        
         $this->query = $query;
     }
 

--- a/src/Query/Logic/LowerThanLogic.php
+++ b/src/Query/Logic/LowerThanLogic.php
@@ -22,21 +22,19 @@ class LowerThanLogic extends AbstractOperation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $value
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         $value
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->value = $value;
         $this->rethink = $rethink;
-        $this->message = $message;
+        
         $this->query = $query;
     }
 

--- a/src/Query/Logic/NotEqualLogic.php
+++ b/src/Query/Logic/NotEqualLogic.php
@@ -22,21 +22,19 @@ class NotEqualLogic extends AbstractOperation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param mixed $value
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         $value
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->value = $value;
         $this->rethink = $rethink;
-        $this->message = $message;
+        
         $this->query = $query;
     }
 

--- a/src/Query/Logic/OrLogic.php
+++ b/src/Query/Logic/OrLogic.php
@@ -22,20 +22,18 @@ class OrLogic extends AbstractOperation
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $functionOne
      * @param QueryInterface $functionTwo
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $functionOne,
         QueryInterface $functionTwo
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
+
         $this->functionOne = $functionOne;
         $this->functionTwo = $functionTwo;
     }

--- a/src/Query/Operation/AbstractOperation.php
+++ b/src/Query/Operation/AbstractOperation.php
@@ -16,7 +16,7 @@ abstract class AbstractOperation extends AbstractAggregation implements Operatio
      */
     public function delete(): QueryInterface
     {
-        return new Delete($this->rethink, $this->message, $this);
+        return new Delete($this->rethink, $this);
     }
 
     /**
@@ -25,10 +25,10 @@ abstract class AbstractOperation extends AbstractAggregation implements Operatio
     public function filter($value): TransformationCompoundInterface
     {
         if ($value instanceof RowInterface) {
-            return new FilterByRow($this->rethink, $this->message, $this, $value);
+            return new FilterByRow($this->rethink, $this, $value);
         }
 
-        return new Filter($this->rethink, $this->message, $this, $value);
+        return new Filter($this->rethink, $this, $value);
     }
 
     /**
@@ -36,7 +36,7 @@ abstract class AbstractOperation extends AbstractAggregation implements Operatio
      */
     public function getAll(...$keys): TransformationCompoundInterface
     {
-        return new GetAll($this->rethink, $this->message, $this, $keys);
+        return new GetAll($this->rethink, $this, $keys);
     }
 
     /**
@@ -44,7 +44,7 @@ abstract class AbstractOperation extends AbstractAggregation implements Operatio
      */
     public function update(array $elements): QueryInterface
     {
-        return new Update($this->rethink, $this->message, $this, $elements);
+        return new Update($this->rethink, $this, $elements);
     }
 
     /**
@@ -52,6 +52,6 @@ abstract class AbstractOperation extends AbstractAggregation implements Operatio
      */
     public function insert(array $document): QueryInterface
     {
-        return new Insert($this->rethink, $this->message, $this, $document);
+        return new Insert($this->rethink, $this, $document);
     }
 }

--- a/src/Query/Operation/DbCreate.php
+++ b/src/Query/Operation/DbCreate.php
@@ -17,15 +17,14 @@ class DbCreate extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param string $name
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message, string $name)
+    public function __construct(RethinkInterface $rethink, string $name)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
+        
         $this->name = $name;
     }
 

--- a/src/Query/Operation/DbDrop.php
+++ b/src/Query/Operation/DbDrop.php
@@ -17,15 +17,14 @@ class DbDrop extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param string $name
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message, string $name)
+    public function __construct(RethinkInterface $rethink, string $name)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
+        
         $this->name = $name;
     }
 

--- a/src/Query/Operation/DbList.php
+++ b/src/Query/Operation/DbList.php
@@ -12,14 +12,12 @@ class DbList extends AbstractQuery
 {
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message)
+    public function __construct(RethinkInterface $rethink)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/Delete.php
+++ b/src/Query/Operation/Delete.php
@@ -18,16 +18,14 @@ class Delete extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message, QueryInterface $query)
+    public function __construct(RethinkInterface $rethink, QueryInterface $query)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/Filter.php
+++ b/src/Query/Operation/Filter.php
@@ -23,22 +23,19 @@ class Filter extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param array $predicate
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         array $predicate
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->predicate = [$predicate];
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/FilterByRow.php
+++ b/src/Query/Operation/FilterByRow.php
@@ -23,22 +23,19 @@ class FilterByRow extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param QueryInterface $manipulation
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         QueryInterface $manipulation
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->functionQuery = $manipulation;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/Get.php
+++ b/src/Query/Operation/Get.php
@@ -23,22 +23,19 @@ class Get extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string|int $key
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         $key
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->key = $key;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/GetAll.php
+++ b/src/Query/Operation/GetAll.php
@@ -23,22 +23,19 @@ class GetAll extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
-     * @param QueryInterface   $query
-     * @param array            $keys
+     * @param QueryInterface $query
+     * @param array $keys
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         array $keys
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query   = $query;
         $this->keys    = $keys;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/IndexCreate.php
+++ b/src/Query/Operation/IndexCreate.php
@@ -23,21 +23,19 @@ class IndexCreate extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $name
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         string $name
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->rethink = $rethink;
-        $this->message = $message;
+
         $this->name = $name;
     }
 

--- a/src/Query/Operation/IndexDrop.php
+++ b/src/Query/Operation/IndexDrop.php
@@ -23,21 +23,19 @@ class IndexDrop extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $name
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         string $name
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->rethink = $rethink;
-        $this->message = $message;
+
         $this->name = $name;
     }
 

--- a/src/Query/Operation/IndexList.php
+++ b/src/Query/Operation/IndexList.php
@@ -18,16 +18,14 @@ class IndexList extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message, QueryInterface $query)
+    public function __construct(RethinkInterface $rethink, QueryInterface $query)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/IndexRename.php
+++ b/src/Query/Operation/IndexRename.php
@@ -28,23 +28,21 @@ class IndexRename extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param string $oldValue
      * @param string $newValue
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         string $oldValue,
         string $newValue
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->rethink = $rethink;
-        $this->message = $message;
+
         $this->oldValue = $oldValue;
         $this->newValue = $newValue;
     }

--- a/src/Query/Operation/Insert.php
+++ b/src/Query/Operation/Insert.php
@@ -22,22 +22,19 @@ class Insert extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param array $documents
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         array $documents
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->documents = [$documents];
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/TableCreate.php
+++ b/src/Query/Operation/TableCreate.php
@@ -17,15 +17,14 @@ class TableCreate extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param string $name
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message, string $name)
+    public function __construct(RethinkInterface $rethink, string $name)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
+
         $this->name = $name;
     }
 

--- a/src/Query/Operation/TableDrop.php
+++ b/src/Query/Operation/TableDrop.php
@@ -17,15 +17,14 @@ class TableDrop extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param string $name
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message, string $name)
+    public function __construct(RethinkInterface $rethink, string $name)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
+        
         $this->name = $name;
     }
 

--- a/src/Query/Operation/TableList.php
+++ b/src/Query/Operation/TableList.php
@@ -12,14 +12,12 @@ class TableList extends AbstractQuery
 {
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message)
+    public function __construct(RethinkInterface $rethink)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Operation/Update.php
+++ b/src/Query/Operation/Update.php
@@ -23,22 +23,19 @@ class Update extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param array $elements
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         array $elements
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->elements = $elements;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Ordening.php
+++ b/src/Query/Ordening.php
@@ -17,11 +17,10 @@ class Ordening extends AbstractQuery implements OrdeningInterface
     /**
      * @param string $key
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      */
-    public function __construct(string $key, RethinkInterface $rethink, MessageInterface $message)
+    public function __construct(string $key, RethinkInterface $rethink)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->asc($key);
     }

--- a/src/Query/Row.php
+++ b/src/Query/Row.php
@@ -34,17 +34,16 @@ class Row extends AbstractQuery implements RowInterface
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param string $value
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         string $value
     ) {
+        parent::__construct($rethink);
+
         $this->value = $value;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**
@@ -59,14 +58,12 @@ class Row extends AbstractQuery implements RowInterface
 
         $this->function = new EqualLogic(
             $this->rethink,
-            $this->message,
-            new GetFieldLogic($this->rethink, $this->message, $this->value),
+            new GetFieldLogic($this->rethink, $this->value),
             $value
         );
 
         $this->query = new FuncLogic(
             $this->rethink,
-            $this->message,
             $this->function
         );
 
@@ -85,14 +82,12 @@ class Row extends AbstractQuery implements RowInterface
 
         $this->function = new NotEqualLogic(
             $this->rethink,
-            $this->message,
-            new GetFieldLogic($this->rethink, $this->message, $this->value),
+            new GetFieldLogic($this->rethink, $this->value),
             $value
         );
 
         $this->query = new FuncLogic(
             $this->rethink,
-            $this->message,
             $this->function
         );
 
@@ -111,14 +106,12 @@ class Row extends AbstractQuery implements RowInterface
 
         $this->function = new LowerThanLogic(
             $this->rethink,
-            $this->message,
-            new GetFieldLogic($this->rethink, $this->message, $this->value),
+            new GetFieldLogic($this->rethink, $this->value),
             $value
         );
 
         $this->query = new FuncLogic(
             $this->rethink,
-            $this->message,
             $this->function
         );
 
@@ -137,14 +130,12 @@ class Row extends AbstractQuery implements RowInterface
 
         $this->function = new GreaterThanLogic(
             $this->rethink,
-            $this->message,
-            new GetFieldLogic($this->rethink, $this->message, $this->value),
+            new GetFieldLogic($this->rethink, $this->value),
             $value
         );
 
         $this->query = new FuncLogic(
             $this->rethink,
-            $this->message,
             $this->function
         );
 
@@ -159,14 +150,12 @@ class Row extends AbstractQuery implements RowInterface
     {
         $this->function = new AndLogic(
             $this->rethink,
-            $this->message,
             $this->function,
             $row->getFunction()
         );
 
         $this->query = new FuncLogic(
             $this->rethink,
-            $this->message,
             $this->function
         );
 
@@ -181,14 +170,12 @@ class Row extends AbstractQuery implements RowInterface
     {
         $this->function = new OrLogic(
             $this->rethink,
-            $this->message,
             $this->function,
             $row->getFunction()
         );
 
         $this->query = new FuncLogic(
             $this->rethink,
-            $this->message,
             $this->function
         );
 

--- a/src/Query/Table.php
+++ b/src/Query/Table.php
@@ -23,14 +23,13 @@ class Table extends AbstractTransformationCompound implements TableInterface
     /**
      * @param string $name
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      */
-    public function __construct(string $name, RethinkInterface $rethink, MessageInterface $message)
+    public function __construct(string $name, RethinkInterface $rethink)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->rethink = $rethink;
-        $this->message = $message;
+        
 
         $this->query = [
             TermType::TABLE,
@@ -45,7 +44,7 @@ class Table extends AbstractTransformationCompound implements TableInterface
      */
     public function get($key): AbstractQuery
     {
-        return new Get($this->rethink, $this->message, $this, $key);
+        return new Get($this->rethink, $this, $key);
     }
 
     /**
@@ -53,7 +52,7 @@ class Table extends AbstractTransformationCompound implements TableInterface
      */
     public function indexCreate(string $name): AbstractQuery
     {
-        return new IndexCreate($this->rethink, $this->message, $this, $name);
+        return new IndexCreate($this->rethink, $this, $name);
     }
 
     /**
@@ -61,7 +60,7 @@ class Table extends AbstractTransformationCompound implements TableInterface
      */
     public function indexDrop(string $name): AbstractQuery
     {
-        return new IndexDrop($this->rethink, $this->message, $this, $name);
+        return new IndexDrop($this->rethink, $this, $name);
     }
 
     /**
@@ -69,7 +68,7 @@ class Table extends AbstractTransformationCompound implements TableInterface
      */
     public function indexList(): AbstractQuery
     {
-        return new IndexList($this->rethink, $this->message, $this);
+        return new IndexList($this->rethink, $this);
     }
 
     /**
@@ -77,7 +76,7 @@ class Table extends AbstractTransformationCompound implements TableInterface
      */
     public function indexRename(string $oldValue, string $newValue): AbstractQuery
     {
-        return new IndexRename($this->rethink, $this->message, $this, $oldValue, $newValue);
+        return new IndexRename($this->rethink, $this, $oldValue, $newValue);
     }
 
     /**

--- a/src/Query/Transformation/AbstractTransformation.php
+++ b/src/Query/Transformation/AbstractTransformation.php
@@ -13,7 +13,7 @@ abstract class AbstractTransformation extends AbstractQuery implements Transform
      */
     public function isEmpty(): QueryInterface
     {
-        return new IsEmpty($this->rethink, $this->message, $this);
+        return new IsEmpty($this->rethink, $this);
     }
 
     /**
@@ -21,7 +21,7 @@ abstract class AbstractTransformation extends AbstractQuery implements Transform
      */
     public function limit($value): TransformationCompoundInterface
     {
-        return new Limit($this->rethink, $this->message, $this, $value);
+        return new Limit($this->rethink, $this, $value);
     }
 
     /**
@@ -29,7 +29,7 @@ abstract class AbstractTransformation extends AbstractQuery implements Transform
      */
     public function skip($value): TransformationCompoundInterface
     {
-        return new Skip($this->rethink, $this->message, $this, $value);
+        return new Skip($this->rethink, $this, $value);
     }
 
     /**
@@ -37,6 +37,6 @@ abstract class AbstractTransformation extends AbstractQuery implements Transform
      */
     public function orderBy($key): TransformationCompoundInterface
     {
-        return new OrderBy($this->rethink, $this->message, $this, $key);
+        return new OrderBy($this->rethink, $this, $key);
     }
 }

--- a/src/Query/Transformation/AbstractTransformationCompound.php
+++ b/src/Query/Transformation/AbstractTransformationCompound.php
@@ -3,11 +3,21 @@ declare(strict_types = 1);
 
 namespace TBolier\RethinkQL\Query\Transformation;
 
+use TBolier\RethinkQL\Query\Logic\GetFieldLogic;
 use TBolier\RethinkQL\Query\Operation\AbstractOperation;
 use TBolier\RethinkQL\Query\QueryInterface;
 
 abstract class AbstractTransformationCompound extends AbstractOperation implements TransformationCompoundInterface
 {
+    /**
+     * @param string $field
+     * @return TransformationCompoundInterface
+     */
+    public function getField(string $field): TransformationCompoundInterface
+    {
+        return new GetFieldLogic($this->rethink, $this->message, $field, $this);
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/Query/Transformation/AbstractTransformationCompound.php
+++ b/src/Query/Transformation/AbstractTransformationCompound.php
@@ -15,7 +15,7 @@ abstract class AbstractTransformationCompound extends AbstractOperation implemen
      */
     public function getField(string $field): TransformationCompoundInterface
     {
-        return new GetFieldLogic($this->rethink, $this->message, $field, $this);
+        return new GetFieldLogic($this->rethink, $field, $this);
     }
 
     /**
@@ -23,7 +23,7 @@ abstract class AbstractTransformationCompound extends AbstractOperation implemen
      */
     public function isEmpty(): QueryInterface
     {
-        return new IsEmpty($this->rethink, $this->message, $this);
+        return new IsEmpty($this->rethink, $this);
     }
 
     /**
@@ -31,7 +31,7 @@ abstract class AbstractTransformationCompound extends AbstractOperation implemen
      */
     public function limit($value): TransformationCompoundInterface
     {
-        return new Limit($this->rethink, $this->message, $this, $value);
+        return new Limit($this->rethink, $this, $value);
     }
 
     /**
@@ -39,7 +39,7 @@ abstract class AbstractTransformationCompound extends AbstractOperation implemen
      */
     public function skip($value): TransformationCompoundInterface
     {
-        return new Skip($this->rethink, $this->message, $this, $value);
+        return new Skip($this->rethink, $this, $value);
     }
 
     /**
@@ -47,6 +47,6 @@ abstract class AbstractTransformationCompound extends AbstractOperation implemen
      */
     public function orderBy($key): TransformationCompoundInterface
     {
-        return new OrderBy($this->rethink, $this->message, $this, $key);
+        return new OrderBy($this->rethink, $this, $key);
     }
 }

--- a/src/Query/Transformation/IsEmpty.php
+++ b/src/Query/Transformation/IsEmpty.php
@@ -18,16 +18,14 @@ class IsEmpty extends AbstractQuery
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      */
-    public function __construct(RethinkInterface $rethink, MessageInterface $message, QueryInterface $query)
+    public function __construct(RethinkInterface $rethink, QueryInterface $query)
     {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Transformation/Limit.php
+++ b/src/Query/Transformation/Limit.php
@@ -22,22 +22,19 @@ class Limit extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param $n
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         int $n
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->n = $n;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Transformation/OrderBy.php
+++ b/src/Query/Transformation/OrderBy.php
@@ -22,22 +22,19 @@ class OrderBy extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param mixed $key
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         $key
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->key = $key;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Transformation/Skip.php
+++ b/src/Query/Transformation/Skip.php
@@ -22,22 +22,19 @@ class Skip extends AbstractTransformationCompound
 
     /**
      * @param RethinkInterface $rethink
-     * @param MessageInterface $message
      * @param QueryInterface $query
      * @param int $n
      */
     public function __construct(
         RethinkInterface $rethink,
-        MessageInterface $message,
         QueryInterface $query,
         int $n
     ) {
-        parent::__construct($rethink, $message);
+        parent::__construct($rethink);
 
         $this->query = $query;
         $this->n = $n;
         $this->rethink = $rethink;
-        $this->message = $message;
     }
 
     /**

--- a/src/Query/Transformation/TransformationCompoundInterface.php
+++ b/src/Query/Transformation/TransformationCompoundInterface.php
@@ -10,6 +10,12 @@ use TBolier\RethinkQL\Response\ResponseInterface;
 interface TransformationCompoundInterface extends OperationInterface
 {
     /**
+     * @param string $field
+     * @return TransformationCompoundInterface
+     */
+    public function getField(string $field): TransformationCompoundInterface;
+
+    /**
      * @return QueryInterface
      */
     public function isEmpty(): QueryInterface;

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -3,6 +3,9 @@ declare(strict_types = 1);
 
 namespace TBolier\RethinkQL\Response;
 
+use TBolier\RethinkQL\Types\Frame\FrameType;
+use TBolier\RethinkQL\Types\Query\QueryType;
+
 class Response implements ResponseInterface
 {
     /**
@@ -57,6 +60,18 @@ class Response implements ResponseInterface
     {
         if (!\is_array($this->data)) {
             return null;
+        }
+
+        if (isset($this->data[0]['$reql_type$']) && $this->data[0]['$reql_type$'] === 'GROUPED_DATA') {
+            $groups = [];
+            foreach ($this->data[0]['data'] as $group) {
+                $groups[] = [
+                    'group' => $group[0],
+                    'reduction' => $group[1],
+                ];
+            }
+
+            return $groups;
         }
 
         return \count($this->data) === 1 && array_key_exists(0, $this->data) ? $this->data[0] : $this->data;

--- a/test/integration/Aggregation/GroupTest.php
+++ b/test/integration/Aggregation/GroupTest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types = 1);
+
+namespace TBolier\RethinkQL\IntegrationTest\Aggregation;
+
+use TBolier\RethinkQL\IntegrationTest\Query\AbstractTableTest;
+use TBolier\RethinkQL\Response\ResponseInterface;
+
+class GroupTest extends AbstractTableTest
+{
+    /**
+     * @return void
+     * @throws \Exception
+     */
+    public function testGroupByDescription(): void
+    {
+        $this->insertDocumentWithNumber(5, 10);
+        $this->insertDocumentWithNumber(4, 10);
+        $this->insertDocumentWithNumber(3, 20);
+        $this->insertDocumentWithNumber(2, 20);
+        $this->insertDocumentWithNumber(1, 30);
+
+        /** @var ResponseInterface $res */
+        $res = $this->r()
+            ->table('tabletest')
+            ->group('description')
+            ->run();
+
+        $this->assertCount(1, $res->getData());
+
+        $this->assertEquals('A document description.', $res->getData()[0]['group']);
+        $this->assertCount(1, $res->getData());
+    }
+
+    /**
+     * @return void
+     * @throws \Exception
+     */
+    public function testGroupByNumber(): void
+    {
+        $this->insertDocumentWithNumber(5, 10);
+        $this->insertDocumentWithNumber(4, 10);
+        $this->insertDocumentWithNumber(3, 20);
+        $this->insertDocumentWithNumber(2, 20);
+        $this->insertDocumentWithNumber(1, 30);
+
+        /** @var ResponseInterface $res */
+        $res = $this->r()
+            ->table('tabletest')
+            ->group('number')
+            ->run();
+
+        $this->assertCount(3, $res->getData());
+
+        $this->assertEquals(10, $res->getData()[0]['group']);
+        $this->assertCount(2, $res->getData()[0]['reduction']);
+
+        $this->assertEquals(20, $res->getData()[1]['group']);
+        $this->assertCount(2, $res->getData()[1]['reduction']);
+
+        $this->assertEquals(30, $res->getData()[2]['group']);
+        $this->assertCount(1, $res->getData()[2]['reduction']);
+    }
+
+    /**
+     * @return void
+     * @throws \Exception
+     */
+    public function testGroupAndMaxByNumberReductionByNumberAndUngroupOrderByNumber(): void
+    {
+        $this->insertDocumentWithNumber('Bob', 10);
+        $this->insertDocumentWithNumber('Alice', 20);
+        $this->insertDocumentWithNumber('Bob', 30);
+        $this->insertDocumentWithNumber('Alice', 40);
+        $this->insertDocumentWithNumber('Harry', 50);
+        $this->insertDocumentWithNumber('Harry', 45);
+
+        /** @var ResponseInterface $res */
+        $res = $this->r()
+            ->table('tabletest')
+            ->group('id')->max('number')->getField('number')
+            ->ungroup()
+            ->orderBy($this->r()->desc('number'))
+            ->run();
+
+        $this->assertCount(3, $res->getData());
+
+        $this->assertEquals('Alice', $res->getData()[0]['group']);
+        $this->assertEquals(20, $res->getData()[0]['reduction']);
+
+        $this->assertEquals('Bob', $res->getData()[1]['group']);
+        $this->assertEquals(10, $res->getData()[1]['reduction']);
+
+        $this->assertEquals('Harry', $res->getData()[2]['group']);
+        $this->assertEquals(50, $res->getData()[2]['reduction']);
+    }
+}


### PR DESCRIPTION
## Purpose

To be able to group and ungroup by a field and do field transformations and manipulations with get field.

```php
/** @var ResponseInterface $res */
        $res = $this->r()
            ->table('tabletest')
            ->group('id')->max('number')->getField('number')
            ->ungroup()
            ->orderBy($this->r()->desc('number'))
            ->run();
```

## Approach

The implementation was focused on aggregation level.

#### Open Questions and Pre-Merge TODOs
- [x] Implement the group aggregation
- [x] Implement the ungroup aggregtation
- [x] Implement the get field transformation so we can reduce to a specified field to transform and manipulate between grouping and ungrouping.

## Research

Researched the other API's (Javascript, Ruby and Java) to make sure we do the correct implementation.

## Solution

This PR adds extra features and does not amend existing ones.

