### PR TITLE
Fixed a bug in update, resulting in Rethink errors.

### DIFF
--- a/src/Query/Operation/Update.php
+++ b/src/Query/Operation/Update.php
@@ -43,7 +43,11 @@ class Update extends AbstractQuery
      */
     public function toArray(): array
     {
-        $jsonElements = json_encode($this->elements);
+        $jsonDocuments = [];
+
+        foreach ($this->elements as $key => $document) {
+            $jsonDocuments[] = json_encode($document);
+        }
 
         return [
             TermType::UPDATE,
@@ -51,9 +55,7 @@ class Update extends AbstractQuery
                 $this->query->toArray(),
                 [
                     TermType::JSON,
-                    [
-                        $jsonElements
-                    ],
+                    $jsonDocuments
                 ],
             ],
         ];

--- a/test/integration/Query/UpdateTest.php
+++ b/test/integration/Query/UpdateTest.php
@@ -30,7 +30,7 @@ class UpdateTest extends AbstractTableTest
         $res = $this->r()
             ->table('tabletest')
             ->filter(['title' => 'Update document'])
-            ->update(['title' => 'Updated document'])
+            ->update([['title' => 'Updated document']])
             ->run();
 
         $this->assertObStatus(['replaced' => $count->getData()], $res->getData());
@@ -51,7 +51,7 @@ class UpdateTest extends AbstractTableTest
         $res = $this->r()
             ->table('tabletest')
             ->filter(['id' => 5])
-            ->update(['title' => 'Updated document'])
+            ->update([['title' => 'Updated document']])
             ->run();
 
         $this->assertObStatus(['replaced' => 1], $res->getData());
@@ -72,7 +72,7 @@ class UpdateTest extends AbstractTableTest
         $res = $this->r()
             ->table('tabletest')
             ->filter(['description' => 'A document description.'])
-            ->update(['title' => 'Updated document'])
+            ->update([['title' => 'Updated document']])
             ->run();
 
         $this->assertObStatus(['replaced' => 5], $res->getData());


### PR DESCRIPTION
## Purpose
The update functionality was creating Arrays instead of Objects, which are required by Rethink.

## Approach
It creates an array with json objects, which then get sent to Rethink

## Solution

I checked how Insert worked, and applied the same solution here.

