### PR TITLE
Fixed a PHP warning when trying to use count() on null

### DIFF
--- a/src/Response/Cursor.php
+++ b/src/Response/Cursor.php
@@ -132,7 +132,13 @@ class Cursor implements \Iterator, \Countable
     {
         $this->index = 0;
         $this->isComplete = $response->getType() === ResponseType::SUCCESS_SEQUENCE;
-        $this->size = $response->isAtomic() ? 1 : \count($response->getData());
+
+        if (\is_null($response->getData())) {
+            $this->size = 0;
+        } else {
+            $this->size = $response->isAtomic() ? 1 : \count($response->getData());
+        }
+
         $this->response = $response;
     }
 

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -82,7 +82,7 @@ class Response implements ResponseInterface
      */
     public function isAtomic(): bool
     {
-        return \is_string($this->data) || \count($this->data) === 1;
+        return \is_string($this->data) || (!\is_null($this->data) && \count($this->data) === 1);
     }
 
     /**


### PR DESCRIPTION
## Purpose
There was a PHP warning being thrown when Rethink has no results (thus resulting in 'null') and trying to count() the result data. This fixes that

## Approach
Added 2 is_null checks.
