### PR TITLE
Add minimum version of PHP in composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
+        "php": "^7.1",
         "psr/http-message": "^1.0",
         "symfony/serializer": "^4.1",
         "symfony/property-access": "^4.1"


### PR DESCRIPTION
## Purpose
Currently anyone can install the package throught composer

## Approach
Set a minimal version into `composer.json`

