### PR TITLE
Getting started example is wrong

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,17 +9,18 @@ Create the Rethink driver object by injecting a `Connection` object into it.
 <?php
 use TBolier\RethinkQL\Rethink;
 use TBolier\RethinkQL\Connection\Registry;
+use TBolier\RethinkQL\Connection\Options;
 
 $connections = [
-    'default_connection' => [
-        'host' => 'localhost',
+    'default_connection' => new Options([
+        'hostname' => 'localhost',
         'port' => 28015,
-        'default_db' => 'demoDB',
-        'user' => 'demo',
-        'password' => 'demo',
+        'dbname' => 'demoDB',
+        'user' => 'admin',
+        'password' => '',
         'timeout' => 5,
-        'timeout_stream' => 10,
-    ],
+        'timeout_stream' => 10
+    ])
 ];
 
 $registry = new Registry($connections);

--- a/readme.md
+++ b/readme.md
@@ -38,17 +38,18 @@ Create the Rethink driver object by injecting a `Connection` object into it.
 <?php
 use TBolier\RethinkQL\Rethink;
 use TBolier\RethinkQL\Connection\Registry;
+use TBolier\RethinkQL\Connection\Options;
 
 $connections = [
-    'default_connection' => [
-        'host' => 'localhost',
+    'default_connection' => new Options([
+        'hostname' => 'localhost',
         'port' => 28015,
-        'default_db' => 'demoDB',
-        'user' => 'demo',
-        'password' => 'demo',
+        'dbname' => 'demoDB',
+        'user' => 'admin',
+        'password' => '',
         'timeout' => 5,
-        'timeout_stream' => 10,
-    ],
+        'timeout_stream' => 10
+    ])
 ];
 
 $registry = new Registry($connections);


### PR DESCRIPTION
The getting started example is wrong.
Registry class constructor require options to be an instance of OptionsInterface.